### PR TITLE
qualify Rolling App Deployments GA

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -2361,10 +2361,14 @@ Excluding droplets or both droplets and packages from your blobstore backup can 
 For more information about the advantages and disadvantages of excluding droplets or excluding both droplets and packages, see [File Storage Backup Level](https://docs.pivotal.io/platform/2-7/customizing/backup-restore/file-storage-backup-level.html). To configure your blobstore backup level, see [Configure File Storage](https://docs.pivotal.io/platform/2-7/customizing/configure-pas.html#file-storage) in _Configuring <%= vars.app_runtime_abbr %>_.
 
 ### <a id='rolling-deployments'></a> Rolling App Deployments Is GA
-
-The rolling app deployments feature is GA. It was released as a beta feature in <%= vars.app_runtime_abbr %> v2.4. This feature allows you to push updates to apps without incurring downtime.
+It was released as a beta feature in <%= vars.app_runtime_abbr %> v2.4. This feature allows you to push updates to apps without incurring downtime.
 
 This feature is enabled by default. You can optionally disable it in the **Advanced Features** pane.
+
+**Important to Note:** 
+- This feature is GA when executed via direct interaction with the v3 CC API or via Apps Manager.
+- The cf CLI implementation of the feature is still experimental (The CLI's implementation is GA in cf CLI v7 
+and it's minimum compatible version of TAS is v2.10.
 
 For more information, see [Rolling App Deployments](https://docs.pivotal.io/platform/2-7/devguide/deploy-apps/rolling-deploy.html).
 


### PR DESCRIPTION
customers are getting confused by the fact that rolling app deployments are GA in TAS v2.7, but the CLI doesn't support them yet.
I've updated the content to reflect the fact that while the feature was GA'd from an API and Apps Man perspective, the v6 CLI that's compatible with TAS v2.7 only has an experimental implementation of the rolling deployment feature.
The feature is fully GA within the cf CLI as of cf CLI v7, which is compatible with TAS v2.10 and above (it cannot be used against TAS 2.7-2.9).

Please feel free to change the copy as you wish. 
The main point I need customers to understand is that the feature is only GA'd from a backend and AppsMan perspective and the CLI's GA of the feature is later in TAS v2.10 and via the V7 cf CLI. feel free to reach out to me via slack if you need to clarify anything. Thanks so much!