### PR TITLE
Add breaking change note for gorouter 1.15 issue

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -174,6 +174,45 @@ For more information, see [Configure CredHub](../../operating/configure-pas.html
 
 <%= vars.app_runtime_abbr %> v2.11 includes the following breaking changes:
 
+### <a id='transfer-encoding-stricter'></a> Gorouter Update to Golang v1.15 Introduces Stricter Transfer-Encoding Header Standards in <%= vars.app_runtime_abbr %> v2.11.0 and Later
+
+In <%= vars.app_runtime_abbr %> v2.11.0 and later,
+stricter header standards break Spring apps
+that incorrectly set the header.
+
+For more details, see the
+[Applications on TAS for VMs get 502 chunked response error](https://community.pivotal.io/s/article/Application-Chunked-Error?language=en_US)
+knowledge base article.
+
+This breaking change was _also present_
+in later patch versions of v2.7, v2.8, v2.9, and v2.10 of <%= vars.app_runtime_abbr %>
+but is listed again here,
+because it is possible to jumpgrade
+directly from a pre-breaking-change patch to  v2.11.
+
+If you have not yet encountered this breaking change,
+you may be on a <%= vars.app_runtime_abbr %> version prior to v2.7.30, v2.8.24, v2.9.20, or 2.10.10.
+
+If this is the case, you should upgrade to a version with a stop-gap version
+of the rouring release
+prior to upgrading to 2.11.0,
+so that you can determine if you have any effected apps.
+
+<%= vars.app_runtime_abbr %> v2.7.31, v2.8.25, v2.9.21, and 2.10.11 include
+a patch release to Gorouter that emits logs,
+emits metrics, and does not error out
+when an app response contains a duplicate
+<code>Transfer-Encoding: chunked</code> header.
+These releases includes a stop-gap fix
+to discover which apps are sending invalid responses.
+This fix is not present in subsequent patch releases.
+For more details, see the
+[Applications on TAS for VMs get 502 chunked response error](https://community.pivotal.io/s/article/Application-Chunked-Error?language=en_US)
+knowledge base article.
+
+Before you upgrade to <%= vars.app_runtime_abbr %> v2.11.00 or later,
+you must follow the resolution steps in the above referenced KB article to fix the apps.
+
 ### <a id='timestamps-breaking-change'></a> Timestamps for Component Logs in Diego Logs when Upgrading
 
 The <strong>Timestamp format for component logs</strong> feature replaces the <strong>Format of timestamps in Diego logs</strong> feature in the <strong>App Containers</strong> pane of the <%= vars.app_runtime_abbr %> tile. However, when you upgrade to <%= vars.app_runtime_abbr %> v2.11, the option that was selected under <strong>Format of timestamps in Diego logs</strong> in your previous deployment is applied to <strong>Timestamp format for component logs</strong>. For more information, see <a href='#timestamps'>Timestamp Format for Component Logs Replaces Timestamp Format for Diego Logs</a>.

--- a/release-notes/segment-rn.html.md.erb
+++ b/release-notes/segment-rn.html.md.erb
@@ -77,8 +77,44 @@ For more information, see [Configure Networking](../../operating/installing-pcf-
 
 ## <a id='breaking-changes'></a> Breaking Changes
 
-There are no breaking changes in this release of <%= vars.segment_runtime_full %>.
+### <a id='transfer-encoding-stricter'></a> Gorouter Update to Golang v1.15 Introduces Stricter Transfer-Encoding Header Standards in <%= vars.app_runtime_abbr %> v2.11.0 and Later
 
+In <%= vars.segment_runtime_full %> v2.11.0 and later,
+stricter header standards break Spring apps
+that incorrectly set the header.
+
+For more details, see the
+[Applications on TAS for VMs get 502 chunked response error](https://community.pivotal.io/s/article/Application-Chunked-Error?language=en_US)
+knowledge base article.
+
+This breaking change was _also present_
+in later patch versions of v2.7, v2.8, v2.9, and v2.10 of <%= vars.segment_runtime_full %>
+but is listed again here,
+because it is possible to jumpgrade
+directly from a pre-breaking-change patch to  v2.11.
+
+If you have not yet encountered this breaking change,
+you may be on a <%= vars.segment_runtime_full %> version prior to v2.7.30, v2.8.24, v2.9.20, or 2.10.10.
+
+If this is the case, you should upgrade to a version with a stop-gap version
+of the rouring release
+prior to upgrading to 2.11.0,
+so that you can determine if you have any effected apps.
+
+<%= vars.segment_runtime_full %> v2.7.31, v2.8.25, v2.9.21, and 2.10.11 include
+a patch release to Gorouter that emits logs,
+emits metrics, and does not error out
+when an app response contains a duplicate
+<code>Transfer-Encoding: chunked</code> header.
+These releases includes a stop-gap fix
+to discover which apps are sending invalid responses.
+This fix is not present in subsequent patch releases.
+For more details, see the
+[Applications on TAS for VMs get 502 chunked response error](https://community.pivotal.io/s/article/Application-Chunked-Error?language=en_US)
+knowledge base article.
+
+Before you upgrade to <%= vars.segment_runtime_full %> v2.11.00 or later,
+you must follow the resolution steps in the above referenced KB article to fix the apps.
 
 ## <a id='known-issues'></a> Known Issues
 


### PR DESCRIPTION
We forgot to account for the Golang 1.15 issue in the router in our release notes.

Though this issue has come up and potentially been resolved in upgrades to previous versions,
re-listing it here seems prudent,
given that customers can jump directly from a version with no warning of this issue to 2.11.0.