### PR TITLE
2.11: Disable ssl certificate verification removed

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -185,6 +185,16 @@ In <%= vars.app_runtime_abbr %>, disabled service plans are handled gracefully i
 
 <%= vars.app_runtime_abbr %> v2.11 includes the following breaking changes:
 
+### <a id='disable-ssl-certificate-verification-removed'></a> "Disable SSL certificate verification for this environment" option removed
+
+In <%= vars.app_runtime_abbr %> v2.11.0 and later the option to disable SSL certificate verification has been removed.
+
+Attempts to upgrade to v2.11.0+ with 'Disable SSL certificate verification for this environment' selected will fail with the following error:
+
+```
+attempt to upgrade to PAS 2.11+ with Skip SSL Verification enabled, please disable Skip SSL Verification prior to upgrade by un-checking "Disable SSL certificate verification for this environment" under "Networking"
+```
+
 ### <a id='transfer-encoding-stricter'></a> Gorouter Update to Golang v1.15 Introduces Stricter Transfer-Encoding Header Standards in <%= vars.app_runtime_abbr %> v2.11.0 and Later
 
 In <%= vars.app_runtime_abbr %> v2.11.0 and later,


### PR DESCRIPTION
The "Disable SSL certificate verification" option has been removed in 2.11.

Co-authored-by: Amin Jamali <ajamali@pivotal.io>