### PR TITLE
Include "Disable SSL Certificate Verification" property name in breaking changes section

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -200,6 +200,8 @@ Skip SSL Verification prior to upgrade by un-checking "Disable SSL certificate
 verification for this environment" under "Networking"
 </pre>
 
+Customers who are automating the installation of <%= vars.app_runtime_abbr %> 2.11 must remove references to the corresponding property `.ha_proxy.skip_cert_verify`.
+
 ### <a id='transfer-encoding-stricter'></a> Gorouter Update to Golang v1.15 Introduces Stricter Transfer-Encoding Header Standards in <%= vars.app_runtime_abbr %> v2.11.0 and Later
 
 In <%= vars.app_runtime_abbr %> v2.11.0 and later,

--- a/release-notes/segment-rn.html.md.erb
+++ b/release-notes/segment-rn.html.md.erb
@@ -91,6 +91,9 @@ attempt to upgrade to IST 2.11+ with Skip SSL Verification enabled, please disab
 Skip SSL Verification prior to upgrade by un-checking "Disable SSL certificate
 verification for this environment" under "Networking"
 </pre>
+
+Customers who are automating the installation of <%= vars.segment_runtime_full %> 2.11 must remove references to the corresponding property `.properties.skip_cert_verify`.
+
 ### <a id='transfer-encoding-stricter'></a> Gorouter Update to Golang v1.15 Introduces Stricter Transfer-Encoding Header Standards in <%= vars.segment_runtime_full %> v2.11.0 and Later
 
 In <%= vars.segment_runtime_full %> v2.11.0 and later,

--- a/release-notes/segment-rn.html.md.erb
+++ b/release-notes/segment-rn.html.md.erb
@@ -87,7 +87,7 @@ For more information, see _Configure Networking_ in [Configuring <%= vars.segmen
 If the **Disable SSL certificate verification for this environment** option is enabled when you try to upgrade to <%= vars.segment_runtime_full %>, the upgrade fails with the following error:
 
 <pre class="terminal">
-attempt to upgrade to PAS 2.11+ with Skip SSL Verification enabled, please disable
+attempt to upgrade to IST 2.11+ with Skip SSL Verification enabled, please disable
 Skip SSL Verification prior to upgrade by un-checking "Disable SSL certificate
 verification for this environment" under "Networking"
 </pre>


### PR DESCRIPTION
For historical reasons this tile property name is non-obvious.

It's helpful to mention the name of the property in the breaking changes section to ensure that customers can update their automation.