### PR TITLE
Wrong indentation with one of bug fixes

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -521,7 +521,7 @@ on the Cloud Foundry website.
 * **[Feature Improvement]** Internal route staleness threshold is now configurable
 * **[Bug Fix]** ServiceDiscoveryController - Reconnect internal routing metrics to the firehose
 * **[Bug Fix]** NATS - Bump release to v38 to fix various issues
-**[Bug Fix]** Gorouter performs TLS to backends when "Skip SSL Certificate Verification" is enabled. Stale routes are now pruned.
+* **[Bug Fix]** Gorouter performs TLS to backends when "Skip SSL Certificate Verification" is enabled. Stale routes are now pruned.
 * Bump ubuntu-xenial stemcell to version `621.87`
 * Bump cf-networking to version `2.34.0`
 * Bump cflinuxfs3 to version `0.209.0`


### PR DESCRIPTION
I found the wrong indentation with one of bug fixes for TAS 2.9.14. Now, fixed it.