### PR TITLE
Add indentation with fix for TAS 2.10.6

### DIFF
--- a/release-notes/runtime-rn.html.md.erb
+++ b/release-notes/runtime-rn.html.md.erb
@@ -605,7 +605,7 @@ on the Cloud Foundry website.
 * **[Feature Improvement]** Internal route staleness threshold is now configurable
 * **[Bug Fix]** ServiceDiscoveryController - Reconnect internal routing metrics to the firehose
 * **[Bug Fix]** NATS - Bump release to v38 to fix various issues
-**[Bug Fix]** Gorouter performs TLS to backends when "Skip SSL Certificate Verification" is enabled. Stale routes are now pruned.
+* **[Bug Fix]** Gorouter performs TLS to backends when "Skip SSL Certificate Verification" is enabled. Stale routes are now pruned.
 * Bump ubuntu-xenial stemcell to version `621.87`
 * Bump cf-networking to version `2.34.0`
 * Bump cflinuxfs3 to version `0.209.0`


### PR DESCRIPTION
Add indentation with following fix for TAS 2.10.6
- [Bug Fix] Gorouter performs TLS to backends when “Skip SSL Certificate Verification” is enabled. Stale routes are now pruned.