### PR TITLE
Discrete performance numbers are not published

### DIFF
--- a/monitoring/kpi.html.md.erb
+++ b/monitoring/kpi.html.md.erb
@@ -13,6 +13,8 @@ This alerting and response guidance has been shown to apply to most deployments.
 
 <p class="note"><strong>Note:</strong> Thresholds noted as "dynamic" in the tables below indicate that while a metric is highly important to watch, the relative numbers to set threshold warnings at are specific to a given <%= vars.app_runtime_abbr %> deployment and its use cases. These dynamic thresholds should be occasionally revisited because the <%= vars.platform_name %> foundation and its usage continue to evolve. For more information, see <a href="metrics.html#thresholds">Warning and Critical Thresholds</a> in <em>Selecting and Configuring a Monitoring System</em>.</p>
 
+While impacting performance to TAS is considered when building new features, discrete load and scale testing is not performed on a regular basis. It is impossible to test each configuration of TAS with each permutation of infrastructure and application workload. Therefore, VMware recommends using the following KPI's to identify when to scale your system.
+
 For more information about accessing metrics used in these key performance indicators, see <a href="https://docs.pivotal.io/application-service/2-11/loggregator/data-sources.html">Overview of Logging and Metrics</a>.
 
 ## <a id="auctioneer"></a> Diego Auctioneer Metrics


### PR DESCRIPTION
This explains why discrete performance numbers are not published. Based on this request: https://vmware.aha.io/ideas/ideas/TAS-I-210 it appears we should at least document why we are not publishing discrete performance numbers.