### PR TITLE
Document CVE-2021-36221 in the release notes

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -39,6 +39,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 **Release Date:** 09/09/2021
 
+* **[Security Fix]** Gorouter built with Go 1.16.7 to address [CVE-2021-36221](https://nvd.nist.gov/vuln/detail/CVE-2021-36221)
 * **[Bug Fix]** CAPI - Some metrics for CAPI were not being properly emitted
 * Bump backup-and-restore-sdk to version `1.18.16`
 * Bump bpm to version `1.1.13`

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -25,6 +25,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 **Release Date:** 09/09/2021
 
+* **[Security Fix]** Gorouter built with Go 1.16.7 to address [CVE-2021-36221](https://nvd.nist.gov/vuln/detail/CVE-2021-36221)
 * **[Bug Fix]** garden-runc - recover after cell restarts
 * Bump bpm to version `1.1.13`
 * Bump cflinuxfs3 to version `0.252.0`


### PR DESCRIPTION
Gorouter built with Go 1.16.7 to address [CVE-2021-36221](https://nvd.nist.gov/vuln/detail/CVE-2021-36221).