### PR TITLE
Add TAS/IST known issue HAPRoxy HTTP/2 support

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -219,4 +219,8 @@ Clients that connect to apps using the Gorouter are not affected.
 
 ## <a id='known-issues'></a> Known Issues
 
-<%= vars.app_runtime_abbr %> <%= vars.v_major_version %> includes no known issues.
+<%= vars.app_runtime_abbr %> v2.12 includes the following known issue:
+
+### <a id="haproxy-http2"></a> HAProxy Does Not Support HTTP/2
+
+<%= partial "/pcf/tas/known-issues/haproxy-http2" %>

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -125,4 +125,8 @@ Clients that connect to apps using the Gorouter are not affected.
 
 ## <a id='known-issues'></a> Known Issues
 
-Isolation Segment v2.12 includes no known issues.
+<%= vars.segment_runtime_full %> v2.12 includes the following known issue:
+
+### <a id="haproxy-http2"></a> HAProxy Does Not Support HTTP/2
+
+<%= partial "/pcf/tas/known-issues/haproxy-http2" %>


### PR DESCRIPTION
I don't have access to submit a PR to pivotal-cf/docs-partials, so here is the associated partial: https://github.com/pet-forks/docs-partials/commit/6a52f71f04d633f54540c5c749ca65af9d4aca0c

[cloudfoundry/routing-release#200]

Authored-by: Greg Cobb <gcobb@pivotal.io>