### PR TITLE
TAS 2.11: Update CAPI release notes to add Label Selector CVE link

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -26,7 +26,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 **Release Date:** 10/19/2021
 
-* **[Security Fix]** CAPI - Cap label selectors at 50 in queries and improve label selector performance to mitigate DOS
+* **[Security Fix]** CAPI - Cap label selectors at 50 in queries and improve label selector performance to mitigate DOS vulnerability [CVE-2021-22101](https://www.cloudfoundry.org/blog/cve-2021-22101-cloud-controller-is-vulnerable-to-unauthenticated-denial-of-service/)
 * **[Feature Improvement]** Set default for System metrics scrape interval to 15s
 * **[Bug Fix]** Fix certificate rotation by fixing CredHub's import of concatenated certificates
 * **[Bug Fix]** Fix "System metrics scrape interval" configuration in manifest


### PR DESCRIPTION
Update release notes for 2.11.8