### PR TITLE
Add release note for CAPI 2.12.6

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -35,6 +35,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 </div>
 
 * **[Security Fix]** Fix uncontrolled recursion related to Log4j ([CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105))
+* **[Bug Fix]** Cloud Controller Worker: PruneExcessAppRevisions job is now more memory efficient
 * Bump credhub to version `2.9.8`
 * Bump java-offline-buildpack to version `4.47`
 * Bump uaa to version `74.5.30`


### PR DESCRIPTION
We released a bug fix in capi release version `1.117.2` to help make the Cloud Controller Worker more memory efficient