### PR TITLE
gorouter: add note for zipkin breaking change 2.12

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -36,8 +36,10 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 * **[Security Fix]** Fix uncontrolled recursion related to Log4j ([CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105))
 * **[Bug Fix]** Cloud Controller Worker: PruneExcessAppRevisions job is now more memory efficient
+* **[Breaking Change]** Gorouter: zipkin `trace-id` size now complies with w3 standard of 16 bytes opposed to the previous 8 bytes.
 * Bump credhub to version `2.9.8`
 * Bump java-offline-buildpack to version `4.47`
+* Bump routing to version `0.227.0`
 * Bump uaa to version `74.5.30`
 
 <table border="1" class="nice">


### PR DESCRIPTION
### Info
In routing-release `0.227.0`, zipkin headers are now generated with a
size of 16 bytes instead of 8 bytes.

### Relevant Links
- [NETWRK-76](https://pivotal-io.atlassian.net/browse/NETWRK-76)
- [Pivotal Tracker #179870729](https://www.pivotaltracker.com/n/projects/2477027/stories/179870729)
- [gorouter#299](cloudfoundry/gorouter#299)

### Related PRs:
- https://github.com/pivotal-cf/docs-pas/pull/145
- https://github.com/pivotal-cf/docs-pas/pull/146
- https://github.com/pivotal-cf/docs-pas/pull/147
- https://github.com/pivotal-cf/docs-pas/pull/148
- https://github.com/pivotal-cf/docs-pas/pull/149