### PR TITLE
gorouter: add note for zipkin breaking change 2.7

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -204,6 +204,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 * **[Security Fix]** Java and PHP Buildpacks - Fix remote code execution vulnerability related to Log4j ([CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228))
 * **[Bug Fix]** Fix "pre-start scripts failed. Failed Jobs: policy-server" error Upgrading to CF Networking Release 2.40.0
 * **[Bug Fix]** Enabling audit logging file rotation to reduce IO load during log rotation
+* **[Breaking Change]** Gorouter: zipkin `trace-id` size now complies with w3 standard of 16 bytes opposed to the previous 8 bytes.
 * Bump backup-and-restore-sdk to version `1.18.28`
 * Bump cf-autoscaling to version `242`
 * Bump cf-networking to version `2.42.0`


### PR DESCRIPTION
### Info
In routing-release `0.227.0`, zipkin headers are now generated with a
size of 16 bytes instead of 8 bytes.

### Relevant Links
- [NETWRK-76](https://pivotal-io.atlassian.net/browse/NETWRK-76)
- [Pivotal Tracker #179870729](https://www.pivotaltracker.com/n/projects/2477027/stories/179870729)
- [gorouter#299](cloudfoundry/gorouter#299)

### Related PRs:
- https://github.com/pivotal-cf/docs-pas/pull/145
- https://github.com/pivotal-cf/docs-pas/pull/146
- https://github.com/pivotal-cf/docs-pas/pull/147
- https://github.com/pivotal-cf/docs-pas/pull/148
- https://github.com/pivotal-cf/docs-pas/pull/149