### PR TITLE
Add bug notice for autoscaling race condition fix

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -38,6 +38,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 * **[Feature]** Monit thresholds for Cloud Controller Worker are configurable
 * **[Feature Improvement]** Golang v1.17 contains stricter IP parsing standards, so IP addresses with leading zeros in any octets cause a BOSH template failure. Operators can remove the leading zeros and try deploying again. This affects properties that feed into cf-networking-release and silk-release.
 * **[Bug Fix]** Cloud Controller Worker - PruneExcessAppRevisions job is more memory efficient
+* **[Bug Fix]** Fix race conditions in autoscaler which could cause autoscaler to crash
 * Bump backup-and-restore-sdk to version `1.18.31`
 * Bump binary-offline-buildpack to version `1.0.42`
 * Bump bosh-system-metrics-forwarder to version `0.0.21`


### PR DESCRIPTION
Autoscaler 243 fixes a few race conditions which could cause the app to crash.