### PR TITLE
Highlight need to allow cells to talk to Log Cache Syslog Server

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -824,6 +824,8 @@ This change comes with the following considerations when you upgrade to <%= vars
 * Be sure to scale up your Log Cache instance count. VMware recommends scaling up to match the number of VMs and amount of memory as your Doppler instances before the upgrade.
   Underscaled Log Cache instances can fail with `Out of Memory` errors, which locks the BOSH Director. Starting larger and then adjusting for actual use is safer than a deployment failure.
 * With Log Cache as its own instance group, you can reduce the memory allocation for Doppler instances.
+* Log Cache now uses syslog ingress by default. Check that your Diego Cells (including any Isolation Segment Diego Cells) are permitted to establish connections to Log Cache nodes on port 6067.
+  You may have firewall rules that will need to be updated to allow logs to flow directly from your Diego Cells to the Log Cache Syslog Server.
 * You might experience temporary difficulties getting logs and metrics from the cf CLI for apps that are pushed during this upgrade.
   This should not affect whether or not the app is able to be deployed.
 * Service instance metrics might not be retrievable using the `log-cache` cf CLI plugin.


### PR DESCRIPTION
* With Log Cache now configured to do syslog ingress by default, operators that have not allowed connections to be established from Diego Cells to Log Cache nodes on port 6067 would see logs fail to appear in Log Cache on upgrade
* Call this change out in the release notes so that operators can open this port prior to upgrading