### PR TITLE
Document system metrics breaking changes

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -360,6 +360,19 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %> includes the following breaking changes:
 
+### <a id='system-metrics'></a> System Metrics Changes
+
+Support for the deprecated BOSH System Metrics Server has been removed. System metrics with the prefix 'system.' are no longer emitted.
+
+To continue to receive system metrics Operators must ensure that the "Enable System Metrics (recommended)" option is selected under the BOSH Director configuration
+in Ops Manager.
+
+Metric names will now be emitted with periods replaced by underscores. For example the previous `system.cpu.sys` metric will now be emitted as `system_cpu_sys`.
+
+Operators should change any alerting or dashboards to use the replacement metrics of the form `system_cpu_sys`.
+
+The source_id for the supported metrics is `system_metrics_agent` instead of the deprecated `bosh-system-metrics-forwarder`. Any queries which reference the old source_id must be updated.
+
 ## <a id='known-issues'></a> Known Issues
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %> includes the following known issues:


### PR DESCRIPTION
- Operators must enable the "Enable System Metrics (recommended)" option
- Metric names and source_id have changed