### PR TITLE
Document syslog drain breaking change (2.11)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -33,6 +33,7 @@ For more information, see [Upgrading to cf CLI v7](../cf-cli/v7.html).
 * **[Feature Improvement]** Add option to configure CC BBR health check timeout
 * **[Feature Improvement]** Enforce service name uniqueness in shared services in spaces
 * **[Bug Fix]** Service offerings now appear to users in orgs/spaces with the appropriate service access
+* **[Breaking Change]** Syslog drains configured to use TLS now [reject certificates signed with the SHA-1 hash function](https://go.dev/doc/go1.18#sha1).
 * Bump backup-and-restore-sdk to version `1.18.39`
 * Bump binary-offline-buildpack to version `1.0.43`
 * Bump capi to version `1.109.9`

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -18,6 +18,7 @@ releasing a MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> contai
 
 **Release Date:** 04/20/2022
 
+* **[Breaking Change]** Syslog drains configured to use TLS now [reject certificates signed with the SHA-1 hash function](https://go.dev/doc/go1.18#sha1).
 * Bump cflinuxfs3 to version `0.285.0`
 * Bump diego to version `2.62.0`
 * Bump loggregator-agent to version `6.3.11`


### PR DESCRIPTION
- Certificates using SHA-1 will now be rejected
- This is a result of bumping loggregator-agent-release to Go 1.18
- We expect most users to be unaffected