### PR TITLE
Document autoscaler manual database index issue (2.11)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -104,6 +104,7 @@ This version contains Diego 2.64.0, which bumps to Go 1.18. Go 1.18 no longer su
 * **[Security Fix]** Added Content-Security-Policy headers in UAA responses
 * **[Bug Fix]** Sticky sessions no longer break when used with route-services that return HTTP 4xx/5xx responses
 * **[Bug Fix/Improvement]** Stop emitting debug metrics for agents and log-cache by default. Reduces load on logging system by >=720 metrics per vm per minute
+* **[Breaking Change]** App Autoscaler: customers who followed the instructions in [this knowledge base article](https://community.pivotal.io/s/article/Autoscale-application-errors-with-MySQL-Deadlock) to manually add a database index will experience an error on upgrade if the index is not dropped prior to upgrading.
 * Bump backup-and-restore-sdk to version `1.18.42`
 * Bump binary-offline-buildpack to version `1.0.45`
 * Bump bosh-system-metrics-forwarder to version `0.0.22`

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -104,7 +104,7 @@ This version contains Diego 2.64.0, which bumps to Go 1.18. Go 1.18 no longer su
 * **[Security Fix]** Added Content-Security-Policy headers in UAA responses
 * **[Bug Fix]** Sticky sessions no longer break when used with route-services that return HTTP 4xx/5xx responses
 * **[Bug Fix/Improvement]** Stop emitting debug metrics for agents and log-cache by default. Reduces load on logging system by >=720 metrics per vm per minute
-* **[Breaking Change]** App Autoscaler: customers who followed the instructions in [this knowledge base article](https://community.pivotal.io/s/article/Autoscale-application-errors-with-MySQL-Deadlock) to manually add a database index will experience an error on upgrade if the index is not dropped prior to upgrading.
+* **[Breaking Change]** If you followed the procedure in [Autoscale application fails with MySQL Deadlock errors](https://community.pivotal.io/s/article/Autoscale-application-errors-with-MySQL-Deadlock) to manually add an index to an Autoscale database, and the index is not dropped before you upgrade to TAS for VMs v2.11.20, upgrading causes an error.
 * Bump backup-and-restore-sdk to version `1.18.42`
 * Bump binary-offline-buildpack to version `1.0.45`
 * Bump bosh-system-metrics-forwarder to version `0.0.22`


### PR DESCRIPTION
* Document that customers will not be able to successfully upgrade without first dropping a manually-added database index.
* I've added the note to the version in which this issue was introduced, though it is also present in later versions.
* I've categorised this as a Breaking Change but it is perhaps more accurately a known issue.