### PR TITLE
Remove warning about golang 1.18 changes 2.11

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -176,8 +176,6 @@ For more information, see [Upgrading to cf CLI v7](../cf-cli/v7.html).
 
 **Release Date:** 06/23/2022
 
-<p class="note warning"><strong style="text-transform: none">Warning: Upcoming reduction in maintenance and security release coverage</strong><br> In future patches, no sooner than July 1st 2022, some TAS components will become more strict about the protocols used in TLS communications, causing integrations with systems using older, insecure protocols to fail. Specifically, components that use Go will no longer support TLS 1.0 or 1.1, or certificates using SHA-1. Use supported TLS protocols to avoid breaking changes and continue receiving maintenance and security releases.</p>
-
 * Bump diego to version `2.62.0`
 
 <table border="1" class="nice">


### PR DESCRIPTION
This PR removes the warning about the upgrade to golang 1.18 in the networking and diego components. It will no longer be necessary after the next release.

This PR is related to this set of PRs:
- https://github.com/pivotal-cf/docs-pas/pull/199
- https://github.com/pivotal-cf/docs-pas/pull/200
- https://github.com/pivotal-cf/docs-pas/pull/201
- https://github.com/pivotal-cf/docs-pas/pull/202

These PR should *not* be merged until [TAS Issue 8426](https://github.com/pivotal/tas/issues/8426) has been resolved and the associated TAS versions have been released.