### PR TITLE
Remove known issue on NCP

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -449,9 +449,6 @@ This upgrade is not currently known to impact tiles that are compatible with <%=
 
 The Ubuntu 22.04 long-term support (LTS) stemcell, Jammy Jellyfish, is not yet CIS- or STIG-certified.
 
-### <a id='ncp-compatibility'></a> VMware NSX-T Container Plug-In Stemcell Compatibility
-
-The VMware NSX-T Container Plug-in is not yet validated on the Jammy Jellyfish stemcell.
 
 ### <a id='uaa-sso-copy'></a> UAA Single Sign-On Copy Button is Broken
 


### PR DESCRIPTION
The NSX-T team has validated that the NCP 4.01 tile works with Jammy stemcells on TAS 3.0.0