### PR TITLE
[2.13.11] Add missing release note for capi parsing apps manifest

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -27,6 +27,7 @@ v8](../../cf-cli/v8.html).
 
 * **[Security Fix]** Bump of nodejs-offline-buildpack to version 4.8.3 fully addresses CVE-2022-3602 and CVE-2022-3786 in OpenSSL 3.x; impacted versions of OpenSSL are otherwise not used in this version line of TAS.
 * **[Feature]** Add "Max request header size in kb" property to Networking tab to allow operators to specify a limit on the aggregate size of request headers. Requests over this limit receive a 431 status code.
+* **[Bug Fix]** Fix capi parsing of apps manifest
 * Bump backup-and-restore-sdk to version `1.18.57`
 * Bump binary-offline-buildpack to version `1.0.47`
 * Bump bosh-system-metrics-forwarder to version `0.0.27`


### PR DESCRIPTION
This release note was missed so making a pr to add it in