### PR TITLE
feat: list BOSH VM CPU and Memory KPI removal in breaking changes

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -3127,6 +3127,12 @@ This metric was also difficult to monitor because it is an aggregate of signals 
 Because the usefulness of monitoring this metric is unclear, and the complexity of interpreting the metric has increased, we are removing it from the KPIs.
 TAS still emits the ActiveLocks metric, but we no longer encourage users to actively monitor it.
 
+### <a id='activelocks-kpi-removed'></a> BOSH VM CPU and Memory removed from Key Performance Indicators (KPIs)
+
+In the past, the TAS documentation recommended monitoring the VM CPU and Memory metrics emitted by all BOSH VMs.
+In practice, not all VMs are worth monitoring this closely, and different VMs and BOSH jobs have different normal CPU and memory loads, making a one-size-fits-all monitoring guideline impractical.
+In the future, the TAS documentation will recommend monitoring BOSH VM metrics for some, but not all, BOSH VMs.
+
 ## <a id='known-issues'></a> Known Issues
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %> includes the following known issues:


### PR DESCRIPTION
This PR proposes removing the BOSH VM CPU and Memory metrics from the TAS KPIs. The commit includes a brief summary of the reasoning for removing the KPI. My team has found that the guidance for this KPI is too vague and broadly monitoring VM metrics from all BOSH VMs leads to over-alerting in our environments.