### PR TITLE
Add 4.0 release note to check nats server version

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1941,7 +1941,7 @@ Gorouter** property in the Networking tab. Any entries that are not valid CA
 certificates will result in an error in OpsManager. Users should remove or replace
 invalid entries.
 
-## <a id='known-issues'></a> Known Issues
+## <a id='known-issues'></a> Known issues
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %> includes the following known issues:
 
@@ -1950,7 +1950,7 @@ invalid entries.
 The Ubuntu 22.04 long-term support (LTS) stemcell, Jammy Jellyfish, is not yet CIS or STIG-certified.
 
 
-### <a id='auto-reconfig-disallowed'></a> java-offline-buildpack v4.52 Disallows Spring Auto Reconfiguration by Default
+### <a id='auto-reconfig-disallowed'></a> java-offline-buildpack v4.52 Disallows Spring Auto Reconfiguration by default
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %>.0 includes `java-offline-buildpack` v4.52, which disallows Spring Auto Reconfiguration by default.
 This change creates the following issues:
@@ -1983,7 +1983,7 @@ Deprecation of Spring Cloud Connectors & Spring Auto
 Reconfiguration](https://community.pivotal.io/s/article/Java-Buildpack-Deprecation-of-Spring-Cloud-Connectors-Spring-Auto-Reconfiguration) in the VMware Tanzu
 Knowledge Base.
 
-### <a id='uaa-sso-copy'></a> UAA Single Sign-On Copy Button is Broken
+### <a id='uaa-sso-copy'></a> UAA Single Sign-On Copy button is broken
 
 In the User Account and Authentication (UAA) user interface (UI), the button that copies Single Sign-On (SSO) codes does not work.
 
@@ -2008,12 +2008,12 @@ those log lines are tagged with old application names.
 To mitigate this issue customers can restart applications after they are renamed.
 
 
-### <a id='check-nats-server-version'></a> Please Check your NATS Server Version
+### <a id='check-nats-server-version'></a> Check your NATS server version
 
-In TAS 2.11.26, we introduced a `nats` release that replaced the underlying package from NATS v1.0 to NATS v2.0. TAS 4.0 is the first LTS version that includes
-NATS v2.0. The migration should happen invisibly; however if the migration is not successful, your nats servers may still be running NATS v1.0. 
+In TAS 2.11.26, VMware introduced a `nats` release that replaced the underlying package from NATS v1.0 to NATS v2.0. TAS for VMx 4.0 is the first LTS version that includes
+NATS v2.0. The migration should happen invisibly; however if the migration is not successful, your NATS servers may still be running NATS v1.0. 
 
-Per the [TAS Support Lifecycle Policy](https://docs.pivotal.io/application-service/3-0/release-notes/runtime-rn.html#support-policy), we will 
-keep the NATS v1.0 as a fallback, but will remove it in a future version. Please follow the [knolwledge base article here](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US) 
+Per the [TAS Support Lifecycle Policy](https://docs.pivotal.io/application-service/3-0/release-notes/runtime-rn.html#support-policy), VMware will 
+keep the NATS v1.0 as a fallback, but will remove it in a future version. Follow the instructions in the [Knowledge Base article](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US) 
 to confirm that your `nats` instances have migrated successfully, and see how to troubleshoot if they have not.
 

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -2006,3 +2006,14 @@ Silk emits log lines to application log streams when ASGs are dynamically change
 those log lines are tagged with old application names.
 
 To mitigate this issue customers can restart applications after they are renamed.
+
+
+### <a id='check-nats-server-version'></a> Please Check your NATS Server Version
+
+In TAS 2.11.26, we introduced a `nats` release that replaced the underlying package from NATS v1.0 to NATS v2.0. TAS 4.0 is the first LTS version that includes
+NATS v2.0. The migration should happen invisibly; however if the migration is not successful, your nats servers may still be running NATS v1.0. 
+
+Per the [TAS Support Lifecycle Policy](https://docs.pivotal.io/application-service/3-0/release-notes/runtime-rn.html#support-policy), we will 
+keep the NATS v1.0 as a fallback, but will remove it in a future version. Please follow the [knolwledge base article here](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US) 
+to confirm that your `nats` instances have migrated successfully, and see how to troubleshoot if they have not.
+


### PR DESCRIPTION
As 4.0 is the first LTS release to include the NATS v2 migration, we are adding a Known Issue to ask customers to check that the invisible migration was successful.