### PR TITLE
Add breaking change note for Diego 2.66.3

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -4046,6 +4046,7 @@ Reconfiguration by Default](#auto-reconfig-disallowed) below.
 ### <a id='2-11-26'></a> v2.11.26
 
 **Release Date:** 09/20/2022
+<p class='note warning'><strong style="text-transform: none;">Warning:</strong> Breaking change This version contains Diego 2.66.3, which bumps to Go 1.18. Go 1.18 no longer supports TLS 1.0 and 1.1 connections or certificates with a SHA-1 checksum. This is most likely to affect connections with external databases.</p>
 
 * **[Security Fix]** Bump Cloud Controller Ruby version to 2.7.6 and Go to 1.18.5
 * **[Security Fix]** Bump golang to 1.17.12 in routing release


### PR DESCRIPTION
We added a breaking change note in v2.11.20 - https://docs.vmware.com/en/VMware-Tanzu-Application-Service/2.11/tas-for-vms/runtime-rn.html#2-11-20 (diego v 2.64.0) We then reverted it back to 2.62.0. We bumped diego again in v2.11.26 but didn't add the breaking change note. 