### PR TITLE
Remove NCP compatibility known issue

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -7327,10 +7327,6 @@ To try out apps on this stack before then, you can use the online buildpack, e.g
 
 The Ubuntu 22.04 long-term support (LTS) stemcell, Jammy Jellyfish, is not yet CIS- or STIG-certified.
 
-### <a id='ncp-compatibility'></a> VMware NSX-T Container Plug-In Stemcell Compatibility
-
-The VMware NSX-T Container Plug-in is not yet validated on the Jammy Jellyfish stemcell.
-
 ### <a id='auto-reconfig-disallowed'></a> java-offline-buildpack v4.52 Disallows Spring Auto Reconfiguration by Default
 
 <%= vars.app_runtime_abbr %> <%= vars.v_major_version %>.0 includes `java-offline-buildpack` v4.52, which disallows Spring Auto Reconfiguration by default.


### PR DESCRIPTION
The team has validated that NCP 4.0.1 is jammy compatible