### PR TITLE
Link to kb article for expect 100 continue bug

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -31,7 +31,7 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 * **[Bug Fix]** Prevents cachedownloader from erroneously deleting old entries.
 * **[Bug Fix]** Resolves a race condition in BBS when the replacement for a suspect LRP has started.
 * **[Bug Fix]** Resolves a bug in gorouter where path-based routes could return 503s when no backend endpoints remain, rather than falling back to non-path (hostname-only) routes.
-* **[Bug Fix]** Resolves a [known issue](https://github.com/cloudfoundry/routing-release/blob/develop/docs/go-1.20-expect-100-continue-known-issue.md) around multiple "Expect 100-Continue" responses
+* **[Bug Fix]** Resolves a [known issue](https://community.pivotal.io/s/article/Multiple-HTTP-Expect-100-continue-responses-sent-from-gorouter-to-client-may-cause-unexpected-failures?language=en_US) around multiple "Expect 100-Continue" responses
 * **[Bug Fix]** When a user is deleted, they are now removed from the groups they were members of
 * **[Feature]** For credential Rotation, JSON key sets are now supported in token keys
 * Bump backup-and-restore-sdk to version `1.18.83`

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -26,7 +26,7 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 * **[Bug Fix]** Prevents cachedownloader from erroneously deleting old entries.
 * **[Bug Fix]** Resolves a race condition in BBS when the replacement for a suspect LRP has started.
 * **[Bug Fix]** Resolves a bug in gorouter where path-based routes could return 503s when no backend endpoints remain, rather than falling back to non-path (hostname-only) routes.
-* **[Bug Fix]** Resolves a [known issue](https://github.com/cloudfoundry/routing-release/blob/develop/docs/go-1.20-expect-100-continue-known-issue.md) around multiple "Expect 100-Continue" responses
+* **[Bug Fix]** Resolves a [known issue](https://community.pivotal.io/s/article/Multiple-HTTP-Expect-100-continue-responses-sent-from-gorouter-to-client-may-cause-unexpected-failures?language=en_US) around multiple "Expect 100-Continue" responses
 * Bump bpm to version `1.2.3`
 * Bump cf-networking to version `3.30.0`
 * Bump cflinuxfs3 to version `0.372.0`


### PR DESCRIPTION
Instead of open source github doc. The kb is related to TAS. The github doc is related to open source.