### PR TITLE
add nats breaking change to runtime docs for 5.0

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -5381,8 +5381,8 @@ In TAS 3.0, we migrated the underlying binary for nats-release from gnatsd (NATS
 Before removing the v1 code completely, we're adding a post-start check to confirm that NATS instances
 are running nats-server.
 
-To avoid experiencing a deployment failure, confirm NATS version by following the directions here:
-[How to confirm your nats servers are running NATs v2](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US).
+To avoid experiencing a deployment failure, confirm the NATS version by following the directions here:
+[How to confirm your nats servers are running NATS v2](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US).
 Environments that have successfully upgraded NATS will not experience any change.
 
 ## <a id='known-issues'></a> Known issues

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -5375,6 +5375,16 @@ Comma-separated strings are no longer accepted, instead pass an array of aggrega
   - url: syslog-tls://ANOTHER-HOSTNAME:PORT
 ```
 
+### NATS intentionally fails deployment in post-start in v1.
+
+In TAS 3.0, we migrated the underlying binary for nats-release from gnatsd (NATS v1) to nats-server (NATS v2).
+Before removing the v1 code completely, we're adding a post-start check to confirm that NATS instances
+are running nats-server.
+
+To avoid experiencing a deployment failure, confirm NATS version by following the directions here:
+[How to confirm your nats servers are running NATs v2](https://community.pivotal.io/s/article/How-to-confirm-your-nats-servers-are-running-NATs-v2?language=en_US).
+Environments that have successfully upgraded NATS will not experience any change.
+
 ## <a id='known-issues'></a> Known issues
 
 There are no known issues for <%= vars.app_runtime_full %> <%= vars.v_major_version %>.


### PR DESCRIPTION
Adding nats intentionally failing in post-start if nats instances have not been migrated.

This was approved in https://github.com/pivotal-cf/docs-pas/pull/279, but there may have been merge conflicts that messed up the merge. Thank you!