### PR TITLE
Remove duplicated release note

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -23,7 +23,6 @@ MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> containing that pa
 
 * **[Bug Fix]** Disable silk-datastore-syncer when using NCP
 * **[Bug Fix]** Garden Healthchecks have been re-enabled after fixing a bug during deployments causing failed diego-cells.
-* **[Bug Fix]** Fix autoscaler bosh backup and restore (BBR) scripts
 * Bump backup-and-restore-sdk to version `1.18.88`
 * Bump capi to version `1.158.0`
 * Bump cflinuxfs4 to version `1.30.0`


### PR DESCRIPTION
This bug fix was shipped with TAS 4.0.6 and has an accurate release note reflecting that. Removing this duplicate one.