### PR TITLE
Record Autoscaler bump to JRE 17 as a breaking change (2.13)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -1078,6 +1078,7 @@ v8](../cf-cli/v8.html).
 
 **Release Date:** 07/21/2023
 
+* **[Breaking change]** App Autoscaler now requires JRE 17. If you have customized the java offline buildpack (java_buildpack_offline) to use the Oracle JRE you will need to ensure that JRE 17 is available and that the [JBP_CONFIG_ORACLE_JRE environment variable](https://github.com/cloudfoundry/java-buildpack/blob/main/docs/jre-oracle_jre.md#configuration) is set on the autoscale-api app to select JRE 17.
 * **[Known Issue]** BBR commands such as backup, backup-cleanup, and restore can fail due to a bug in component BBR scripts. Contact [Tanzu Support](https://tanzu.vmware.com/support) for help restoring from a backup if necessary.
 * **[Bug Fix]** Fixes duplicate routes sent to Diego
 * **[Bug Fix]** Updates snakeyaml to resolve CVEs: CVE-2022-1471, CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
@@ -5180,6 +5181,7 @@ returned as 502s, potentially preventing stale route pruning.
 <%= partial "/pcf/tas/known-issues/gorouter-route-unavailability" %>
 <%= partial "/pcf/tas/known-issues/multiple-expect-100-continue-tas-2-13" %>
 
+* **[Breaking change]** App Autoscaler now requires JRE 17. If you have customized the java offline buildpack (java_buildpack_offline) to use the Oracle JRE you will need to ensure that JRE 17 is available and that the [JBP_CONFIG_ORACLE_JRE environment variable](https://github.com/cloudfoundry/java-buildpack/blob/main/docs/jre-oracle_jre.md#configuration) is set on the autoscale-api app to select JRE 17.
 * **[Security Fix]** Apps Manager CVE Fixes
 * **[Security Fix]** Fix BBR scripts and bump spring-boot to address [CVE-2023-20860](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20860) and [CVE-2023-20861](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-20861)
 * **[Bug Fix]** Fix apps-manager failure due to buildpack changes


### PR DESCRIPTION
- It's possible for customers to have replaced the standard java_buildpack_offline with a fork, commonly to use the Oracle JRE.
- This will cause a failure on upgrade if the environment variable JBP_CONFIG_ORACLE_JRE is not set to select JRE 17.
- Document against both 2.13.19 (where the change was made) and 2.13.24 (the first recommended patch following).