### PR TITLE
add readiness health check feature note for 5.0

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -6458,6 +6458,14 @@ timeouts are now configured by the "Front end idle timeout for the Gorouter" pro
 
 ## <a id='new-features'></a> New features in <%= vars.app_runtime_full %> <%= vars.v_major_version %>
 
+### Readiness Health Checks
+
+App Developers can now setup readiness health checks for their apps. Readiness
+health checks are performced to validate that app instances are ready to serve
+requests. When readiness health checks fail, the app instance is marked as not
+ready and removed from the route pool for the app. See this
+<a href='deploy-apps-healthchecks.html'>doc</a> for more information.
+
 ### Add OpenTelemetry Collector (Beta)
 
 In addition to Aggregate Syslog Drains and the Firehose, TAS 5.0 provides beta support for exporting metrics in

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -6464,7 +6464,7 @@ App Developers can now setup readiness health checks for their apps. Readiness
 health checks are performced to validate that app instances are ready to serve
 requests. When readiness health checks fail, the app instance is marked as not
 ready and removed from the route pool for the app. See this
-<a href='deploy-apps-healthchecks.html'>doc</a> for more information.
+<a href='/devguide/deploy-apps/healthchecks.html'>doc</a> for more information.
 
 ### Add OpenTelemetry Collector (Beta)
 


### PR DESCRIPTION
👉 Please make sure that the relative link is correct!!

* release note url: `https://docs.vmware.com/en/VMware-Tanzu-Application-Service/5.0/tas-for-vms/runtime-rn.html`
* doc url: `https://docs.vmware.com/en/VMware-Tanzu-Application-Service/54.0/tas-for-vms/deploy-apps-healthchecks.html`
* relative url (I think): `deploy-apps-healthchecks.html`