### PR TITLE
Recommend operators load test when enabling Collector

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -6481,6 +6481,10 @@ This beta feature allows operators to export metrics over the OpenTelemetry Prot
 different observability platforms. We're excited about the possibilities this provides and interested in any feedback
 you have, including whether additional exporters might be useful.
 
+Enabling the Collector consumes additional resources on each VM. We recommend that operators load test deployments to
+size VMs correctly. Operators with deployments that make use of VM types with CPU bursting should ensure there are
+sufficient reserved vCPUs for the increased CPU consumed.
+
 Note that as this feature is beta, it may still change in significant ways.
 
 ### Log Cache Syslog Server supports mTLS


### PR DESCRIPTION
Operators that are using the newer VM types defaulted to in [Ops Manager 3.0](https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/release-notes.html) should check that they have enough headroom to cope with extra CPU consumed when CPU is being throttled.