### PR TITLE
Clarify introduction of the nats migration in the 4.0 release line

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -8953,7 +8953,7 @@ To mitigate this issue, you can start the applications again after they are rena
 
 In <%= vars.app_runtime_abbr %> 2.11.26, VMware introduced a `nats` release that replaced the
 underlying package from NATS v1.0 with NATS v2.0. <%= vars.app_runtime_abbr %>. Version 4.0 is the first LTS
-version that includes NATS v2.0. The migration happens invisibly. However, if the migration is not
+major version that includes NATS v2.0 from the beginning of the release line. The migration happens invisibly. However, if the migration is not
 successful, your NATS servers might still be running NATS v1.0.
 
 As described in the [TAS Support Lifecycle


### PR DESCRIPTION
There was some confusion about the existing language. I tried to clarify that although 4.0 is the first LTS release line where this change was introduced with the initial patch release (4.0.0), unlike other release lines where it was introduced in a patch release (specifically, the 2.13 release line introduces this in 2.13.14).