### PR TITLE
Reintroduce global log rate limiting

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -5808,6 +5808,20 @@ down to zero. This can significantly reduce costs or free up resources that may 
 You may not be able to scale down to zero if you have integrations or other features that depend on the firehose, such as log and metric nozzles or
 metric registrar.
 
+### Reintroduction of global log rate limit
+
+TAS 3.0 introduced granular app log rate limits for fine-grained control over application log rates.
+
+In TAS 4.0 the older global log rate limit feature **App log rate limit (deprecated)** under **App Containers** was
+removed. This was problematic for operators who were jump upgrading to TAS 4.0 without going through TAS 3.0 as logs
+would not be rate limited until application-based log rate limits were applied.
+
+The global log rate limit is being re-added to enable operators to upgrade while retaining a log rate limit. Operators
+should configure the same setting separately for <%= vars.segment_runtime_full %> and <%= vars.windows_runtime_abbr %>.
+
+If you previously had a global log rate limit set then it will be re-applied following the upgrade to
+<%= vars.app_runtime_full %> <%= vars.v_major_version %>.
+
 ## <a id='breaking-changes'></a> Breaking changes
 
 These are the breaking changes for <%= vars.app_runtime_full %> <%= vars.v_major_version %>.

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Isolation Segment v5.0 Release notes
+title: Isolation Segment v6.0 Release notes
 owner: Release Engineering
 ---
 

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -2984,7 +2984,22 @@ see the [VMware Tanzu Operations Manager documentation](https://docs.vmware.com/
 
 ## <a id='new-features'></a> New features in <%= vars.segment_runtime_full %> <%= vars.v_major_version %>
 
-There are no new features for <%= vars.segment_runtime_full %> <%= vars.v_major_version %>.
+These are the new features for <%= vars.segment_runtime_full %> <%= vars.v_major_version %>.
+
+### Reintroduction of global log rate limit
+
+TAS 3.0 introduced granular app log rate limits for fine-grained control over application log rates.
+
+In <%= vars.segment_runtime_full %> 4.0 the older global log rate limit feature **App log rate limit (deprecated)**
+under **App Containers** was removed. This was problematic for operators who were jump upgrading to
+<%= vars.segment_runtime_full %> 4.0 without going through <%= vars.segment_runtime_full %> 3.0 as logs would not be
+rate limited until application-based log rate limits were applied.
+
+The global log rate limit is being re-added to enable operators to upgrade while retaining a log rate limit. Operators
+should configure the same setting separately for <%= vars.app_runtime_full %> and <%= vars.windows_runtime_abbr %>.
+
+If you previously had a global log rate limit set then it will be re-applied following the upgrade to
+<%= vars.segment_runtime_full %> <%= vars.v_major_version %>.
 
 ## <a id='breaking-changes'></a> Breaking changes
 


### PR DESCRIPTION
* Reintroducing the older global log rate limit to ease customer upgrades, in particular for customers doing jump upgrades.
* The limit needs to be individually configured for TAS, IST and TASW.