### PR TITLE
Remove erroneous breaking change notice

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -411,7 +411,6 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 * **[Feature]** CAPI Enable legacy MD5 buildpack paths
 * **[Feature Improvement]** Allow UAA internal password policy to be independently configurable
 * **[Feature Improvement]** Apps using readiness health checks will now see audit.app.process.notready and audit.app.process.ready events reported to `cf events`
-* **[Breaking Change]** Change default internal route service port to 7070
 * **[Bug Fix]** Resolve cf-autoscaling issue where creation of scheduled limit changes could fail due to the database server not allowing zero dates.
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -264,7 +264,6 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 
 * **[Feature]** Add support for NTLM authentication in Gorouter
 * **[Feature Improvement]** Apps using readiness health checks will now see audit.app.process.notready and audit.app.process.ready events reported to `cf events`
-* **[Breaking Change]** Change default internal route service port to 7070
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention
 * **[Feature Improvement]** Adds opt-in support for NTLM + other challenge-response based authentication using `Authorization: Negotiate` flows by automatically enabling sticky sessions for those requests.


### PR DESCRIPTION
This note got added by mistake by the release notes automation. The breaking change was only introduced in 6.0.