### PR TITLE
Remove erroneous breaking change notice

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -25,7 +25,6 @@ v8](../cf-cli/v8.html).
 
 **Release Date:** 03/04/2024
 
-* **[Breaking Change]** Change default internal route service port to 7070
 * **[Bug Fix]** Resolve cf-autoscaling issue where creation of scheduled limit changes could fail due to the database server not allowing zero dates.
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -21,7 +21,6 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 
 **Release Date:** 03/04/2024
 
-* **[Breaking Change]** Change default internal route service port to 7070
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention
 * **[Feature Improvement]** Adds opt-in support for NTLM + other challenge-response based authentication using `Authorization: Negotiate` flows by automatically enabling sticky sessions for those requests.


### PR DESCRIPTION
This note got added by mistake by the release notes automation. The breaking change was only introduced in 6.0.