### PR TITLE
Document known issue with 2.13.36

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -25,6 +25,7 @@ v8](../cf-cli/v8.html).
 
 **Release Date:** 03/04/2024
 
+* **[Known Issue]]** Foundations with Route Services disabled fail to deploy. Please deploy TAS 2.13.37 instead.
 * **[Bug Fix]** Resolve cf-autoscaling issue where creation of scheduled limit changes could fail due to the database server not allowing zero dates.
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention

--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -25,7 +25,7 @@ v8](../cf-cli/v8.html).
 
 **Release Date:** 03/04/2024
 
-* **[Known Issue]]** Foundations with Route Services disabled fail to deploy. Please deploy TAS 2.13.37 instead.
+* **[Known Issue]]** Foundations with Route Services disabled fail to deploy due to a bug in the TAS tile. This issue has been addressed in TAS 2.13.37.
 * **[Bug Fix]** Resolve cf-autoscaling issue where creation of scheduled limit changes could fail due to the database server not allowing zero dates.
 * **[Security Fix]** Bump docker to address [GHSA-jq35-85cj-fj4p](https://github.com/advisories/GHSA-jq35-85cj-fj4p)
 * **[Feature Improvement]** Garden now emits an `UnkillableContainers` metric to help identify cells that will be unable to redeploy successfully without operator intervention


### PR DESCRIPTION
A bug in this version caused deployment failures when operators disable Route Services. The subsequent version includes a fix.