### PR TITLE
Document known issue in 4.0.19

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -21,6 +21,7 @@ MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> containing that pa
 
 **Release Date:** 03/06/2024
 
+* **[Known Issue]]** Foundations with Route Services disabled fail to deploy due to a bug in the TAS tile. This issue has been addressed in TAS 4.0.20.
 * **[Known Issue]** If you issue a user deletion request during the upgrade to this release, UAA might return an error
 * **[Feature]** Add support for ESM updates on cflinuxfs4 stack
 * Bump backup-and-restore-sdk to version `1.19.3`


### PR DESCRIPTION
A bug in this version caused deployment failures when operators disable Route Services. The subsequent version includes a fix.