### PR TITLE
Global log rate limit has been restored (4.0)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -15677,29 +15677,15 @@ the cf CLI before v6.52.0 cannot retrieve logs when they are called using the `c
 trusted by the Gorouter property in the **Networking** tab. Any entries that are not valid CA
 certificates can cause an error in <%= vars.platform_name %>. You must remove or replace invalid entries.
 
-### Option to enable (deprecated) Global Log Rate Limit is removed
+### Option to activate (deprecated) Global Log Rate Limit was removed (<%= vars.app_runtime_abbr %> 4.0.0+LTS-T - <%= vars.app_runtime_abbr %> 4.0.19+LTS-T)
 
-This feature was in beta until <%= vars.app_runtime_abbr %> 3.0, when it was deprecated. For
-details, see [<%= vars.app_runtime_abbr %> 3.0 Release
-notes](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/runtime-rn.html#global-log-rate-limit-is-deprecated-24).
+The global log rate limit feature was removed in <%= vars.app_runtime_abbr %> 4.0.0+LTS-T. It was restored in
+<%= vars.app_runtime_abbr %> 4.0.20+LTS-T to ease migration to the newer granular app log rate limit feature.
 
-For more information on app log rate limits, see [App Log Rate
-Feature](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/runtime-rn.html#app-log-rate-limits-for-orgs-spaces-and-individual-apps-14).
-The option to activate this feature has now been removed, and you must apply app log rate limits
-instead.
 <p class="note important">
 <span class="note__title">Important</span> If you were using this feature to limit your overall app log throughput, then you might
-see an increase in log load after you upgrade. </p>
-
-To mitigate the increased log load problem, you can either:
-
-* Scale up your logging system before upgrading to TAS v4.0 to compensate for the increased log
-  load.
-
-  Or
-
-* Upgrade to <%= vars.app_runtime_abbr %> 3.0 first to set app-level log rate limits while retaining
-  the global log rate limit. For more details, see [App Log Rate Limits](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/app-log-rate-limits.html).
+see an increase in log load after you upgrade prior to configuring granular app log rate limiting. To avoid the increase ensure you
+upgrade to <%= vars.app_runtime_abbr %> 4.0.20+LTS-T or greater to retain the ability to configure a global log rate limit.</p>
 
 ### Ruby and Python have been removed from the cflinuxfs4 stack
 

--- a/segment-rn.html.md.erb
+++ b/segment-rn.html.md.erb
@@ -6069,22 +6069,15 @@ Gorouter property in the **Networking** tab. Any entries that are not valid CA
 certificates can result in an error in Tanzu Operations Manager. You must remove or replace
 invalid entries.
 
-### Option to activate (deprecated) Global Log Rate Limit is removed
+### Option to activate (deprecated) Global Log Rate Limit was removed (<%= vars.segment_runtime_full %> 4.0.0+LTS-T - <%= vars.segment_runtime_full %> 4.0.19+LTS-T)
 
-This feature was in beta until IST v3.0, when it was deprecated following the introduction of app log rate limits.
+The global log rate limit feature was removed in <%= vars.segment_runtime_full %> 4.0.0+LTS-T. It was restored in
+<%= vars.segment_runtime_full %> 4.0.20+LTS-T to ease migration to the newer granular app log rate limit feature.
 
-For details, see [Isolation Segment v3.0 Release Notes](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/segment-rn.html#global-log-rate-limit-is-deprecated-15) and also [App Log Rate Feature](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/3.0/tas-for-vms/runtime-rn.html#app-log-rate-limits-for-orgs-spaces-and-individual-apps-14).
-The option to enable this feature has now been removed, and you must apply app log rate limits instead.
-<p class="note"><strong>Note:</strong> If you were using this feature to limit your overall app log
-throughput, then you might see an increase in log load after you upgrade. </p>
-To
-mitigate this, either:
-
-* Scale up your logging system before you upgrade to IST v4.0 to compensate for the increased log load.
-
-  Or
-
-* Upgrade to TAS/IST v3.0 first to set app-level log rate limits while retaining the global log rate limit. For details, see [App Log Rate Limits](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/4.0/tas-for-vms/app-log-rate-limits.html).
+<p class="note important">
+<span class="note__title">Important</span> If you were using this feature to limit your overall app log throughput, then you might
+see an increase in log load after you upgrade prior to configuring granular app log rate limiting. To avoid the increase ensure you
+upgrade to <%= vars.segment_runtime_full %> 4.0.20+LTS-T or greater to retain the ability to configure a global log rate limit.</p>
 
 ## <a id='known-issues'></a> Known issues
 


### PR DESCRIPTION
TAS and IST 4.0.20 re-add the global log rate limit feature that was removed in 4.0.0.

- Removed reference to TAS 3.0 release notes that are no longer accessible at that URL.