### PR TITLE
Document UAA SAML IDP breaking change

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -27,6 +27,7 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 * **[Breaking Change]** Replace cpu entitlement counters with cpu_entitlement percentage gauge
 * **[Breaking Change]** Remove (deprecated) Metrics Agent and Metrics Discovery Release
 * **[Breaking Change]**: Move and adapt UAA password complexity policies 
+* **[Breaking Change]**: Remove UAA's ability to serve as a native SAML identity provider (note: operators can continue to configure UAA to connect to an external SAML identity provider via TAS's Authentication and Enterprise SSO pane)
 * **[Breaking Change]** Gorouter's deprecated /varz and /healthz endpoints on port 8080 have been removed
 * **[Feature]** New form option and migration to opt-into allowing Small Footprint TAS to 'full' TAS upgrade.
 * **[Feature]** Add support for NTLM authentication in Gorouter


### PR DESCRIPTION
- This corresponds to the breaking change in UAA v77.0.0
- tries to clarify the distinction between UAA as a "native SAML identity provider" (removed), and UAA as a connector/proxy to an "external SAML identity provider" (NOT removed, and this feature is still explicitly documented in TAS usage docs: "/tas-for-vms/configure-auth.html").

[#187325538]