### PR TITLE
Document App Autoscaler load balancer incompatibility (TAS 2.13)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -5062,6 +5062,7 @@ v8](../cf-cli/v8.html).
 
 **Release Date:** 01/25/2024
 
+* **[Breaking change]** App Autoscaler introduces incompatibility with load balancers that reject POST requests without a Content-Length header.
 * Bump backup-and-restore-sdk to version `1.18.116`
 * Bump binary-offline-buildpack to version `1.1.9`
 * Bump bpm to version `1.2.13`


### PR DESCRIPTION
- Due to Spring Framework 6.1.0 change
- Fix not shipped at time of writing