### PR TITLE
Document App Autoscaler load balancer incompatibility (TAS 4.0)

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -5221,6 +5221,7 @@ MySQL patch and VMware releasing <%= vars.app_runtime_abbr %> containing that pa
 
 * **[Feature Improvement]** Stop logging out of external OIDC provider when logging out of TAS
 * **[Bug Fix]** SMB volumes can be forced to mount with the nodfs flag
+* **[Breaking Change]** App Autoscaler introduces incompatibility with load balancers that reject POST requests without a Content-Length header.
 * Bump backup-and-restore-sdk to version `1.18.116`
 * Bump binary-offline-buildpack to version `1.1.9`
 * Bump bpm to version `1.2.13`


### PR DESCRIPTION
- Due to Spring Framework 6.1.0 change
- Fix not shipped at time of writing