### PR TITLE
Update CLI v7 deprecation notice for TPCF 10.0

### DIFF
--- a/runtime-rn.html.md.erb
+++ b/runtime-rn.html.md.erb
@@ -15,7 +15,7 @@ Because VMware uses the Percona Distribution for MySQL, expect a time lag betwee
 
 <hr>
 
-**Deprecation Notice:** Cloud Foundry Command-Line Interface (cf CLI) v7 is deprecated and will lose support. For how to upgrade to cf CLI v8 see [Upgrading to cf CLI
+**Deprecation Notice:** Cloud Foundry Command-Line Interface (cf CLI) v7 will be deprecated and will lose support starting next release. For how to upgrade to cf CLI v8 see [Upgrading to cf CLI
 v8](../cf-cli/v8.html).
 
 >**Important**


### PR DESCRIPTION
Starting next TPCF release, CF CLI v7 will be deprecated